### PR TITLE
feat: Add fields for Pub/Sub triggers   feat: Implementation of Source Manifests

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -22,5 +22,5 @@ deep-copy-regex:
   - source: /google/devtools/cloudbuild/(v.*)/.*-py/(.*)
     dest: /owl-bot-staging/$1/$2
 
-begin-after-commit-hash: 6a5da3f1274b088752f074da5bc9e30bd1beb27e
+begin-after-commit-hash: 0a3c7d272d697796db75857bac73905c68e498c3
 


### PR DESCRIPTION
PR #98 included changes to the generated client but the conventional commit messages were not included in the PR. This PR updates the begin-after-commit-hash that owl-bot uses to pull changes from googleapis-gen to match [this commit](https://github.com/googleapis/googleapis-gen/search?q=0a3c7d272d697796db75857bac73905c68e498c3&type=commits).

The following changes are already in master:
fix: add async client to %name_%version/init.py
chore: add autogenerated snippets
chore: remove auth, policy, and options from the reserved names list
feat: support self-signed JWT flow for service accounts
chore: enable GAPIC metadata generation
chore: sort subpackages in %namespace/%name/init.py
feat: Add fields for Pub/Sub triggers  
feat: Implementation of Source Manifests

- Added message StorageSourceManifest as an option for the Source message
- Added StorageSourceManifest field to the SourceProvenance message

