### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudbuild",
     "name_pretty": "Cloud Build",
     "product_documentation": "https://cloud.google.com/cloud-build/docs/",
-    "client_documentation": "https://googleapis.dev/python/cloudbuild/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudbuild/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/5226584",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Python Client for Cloud Build API (`GA`_)
 
 .. _GA: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. _Cloud Build API: https://cloud.google.com/cloud-build
-.. _Client Library Documentation: https://googleapis.dev/python/cloudbuild/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudbuild/latest
 .. _Product Documentation:  https://cloud.google.com/cloud-build
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.