### PR TITLE
chore(python): Add example of using client_options for regional endpoints

### DIFF
--- a/samples/snippets/quickstart.py
+++ b/samples/snippets/quickstart.py
@@ -16,6 +16,7 @@
 # [START cloudbuild_quickstart]
 import google.auth
 from google.cloud.devtools import cloudbuild_v1
+from google.api_core import client_options
 
 
 def quickstart():
@@ -23,10 +24,16 @@ def quickstart():
     print the in-progress status and print the completed status."""
 
     # Authorize the client with Google defaults
-    # If you're using Private Pools, add a regional `api_endpoint` to `CloudBuildClient()`
-    # For example, '<YOUR_POOL_REGION>-cloudbuild.googleapis.com'
     credentials, project_id = google.auth.default()
     client = cloudbuild_v1.services.cloud_build.CloudBuildClient()
+
+	# If you're using Private Pools or a non-global default pool, add a regional
+    # `api_endpoint` to `CloudBuildClient()`
+    # For example, '<YOUR_POOL_REGION>-cloudbuild.googleapis.com'
+    # client_options = client_options.ClientOptions(
+    #     api_endpoint="us-central1-cloudbuild.googleapis.com"
+    # )
+    # client = cloudbuild_v1.services.cloud_build.CloudBuildClient(client_options=client_options)
 
     build = cloudbuild_v1.Build()
 

--- a/samples/snippets/quickstart.py
+++ b/samples/snippets/quickstart.py
@@ -16,7 +16,6 @@
 # [START cloudbuild_quickstart]
 import google.auth
 from google.cloud.devtools import cloudbuild_v1
-from google.api_core import client_options
 
 
 def quickstart():
@@ -31,6 +30,7 @@ def quickstart():
     # `api_endpoint` to `CloudBuildClient()`
     # For example, '<YOUR_POOL_REGION>-cloudbuild.googleapis.com'
     #
+    # from google.api_core import client_options
     # client_options = client_options.ClientOptions(
     #     api_endpoint="us-central1-cloudbuild.googleapis.com"
     # )

--- a/samples/snippets/quickstart.py
+++ b/samples/snippets/quickstart.py
@@ -30,6 +30,7 @@ def quickstart():
     # If you're using Private Pools or a non-global default pool, add a regional
     # `api_endpoint` to `CloudBuildClient()`
     # For example, '<YOUR_POOL_REGION>-cloudbuild.googleapis.com'
+    #
     # client_options = client_options.ClientOptions(
     #     api_endpoint="us-central1-cloudbuild.googleapis.com"
     # )

--- a/samples/snippets/quickstart.py
+++ b/samples/snippets/quickstart.py
@@ -27,7 +27,7 @@ def quickstart():
     credentials, project_id = google.auth.default()
     client = cloudbuild_v1.services.cloud_build.CloudBuildClient()
 
-	# If you're using Private Pools or a non-global default pool, add a regional
+    # If you're using Private Pools or a non-global default pool, add a regional
     # `api_endpoint` to `CloudBuildClient()`
     # For example, '<YOUR_POOL_REGION>-cloudbuild.googleapis.com'
     # client_options = client_options.ClientOptions(


### PR DESCRIPTION
The existing regional endpoints comment leaves a lot as an exercise to the reader and is a bit out of date as to what it applies to (e.g. default pools can be regional now).  This provides a code example within comments and including the necessary import for using client options.
